### PR TITLE
Improved error handling

### DIFF
--- a/src/main/java/org/pvv/shufflegene/DinucleotideShuffle.java
+++ b/src/main/java/org/pvv/shufflegene/DinucleotideShuffle.java
@@ -31,7 +31,7 @@ public class DinucleotideShuffle {
      * @param sequence the sequence to be shuffled.
      * @return a string containing a shuffled sequence with the same dinucleotide frequency as the input.
      */
-    public static String shuffleSequence(String sequence) throws InvalidInputException {
+    public static String shuffleSequence(String sequence) throws InvalidInputException, IllegalStateException {
         sequence = sequence.toUpperCase();
         if (!validSequence(sequence)) {
             throw new InvalidInputException(String.format("Input string %s does not conform with alphabet %s\n", sequence, ALPHABET));
@@ -41,7 +41,9 @@ public class DinucleotideShuffle {
         ArrayList<Pair<Character, Character>> edges = pickEdges(traverse);
 
         for (Pair<Character, Character> edge : edges) {
-            traverse.removeEdge(edge);
+            if (!traverse.removeEdge(edge)) {
+                throw new IllegalStateException("Attempted to remove an edge that does not exist. This should never happen");
+            }
         }
 
         traverse.shuffleEdgeLists();
@@ -50,7 +52,7 @@ public class DinucleotideShuffle {
             traverse.appendEdge(edge);
         }
 
-        return traverse.toString();
+        return traverse.unsafeToString();
     }
 
     /**

--- a/src/main/java/org/pvv/shufflegene/Traverse.java
+++ b/src/main/java/org/pvv/shufflegene/Traverse.java
@@ -99,20 +99,18 @@ public class Traverse {
     }
 
     /**
-     * Convert the traverse to a string.
+     * Convert the traverse to a string. This method is unsafe, since it only works when the traverse
+     * is in a fully connected state.
      *
      * @return string with nucleotide sequence
      */
-    public String toString() {
+    public String unsafeToString() throws IllegalStateException {
         StringBuilder result = new StringBuilder();
         HashMap<Character, ArrayList<Character>> edgeMapCopy = copyEdgeMap();
 
         char current = start;
         result.append(start);
 
-        // Fixme: This only works if the traverse is in a valid ordering.
-        // Otherwise it throws an out of bounds exception. Need to think of a better
-        // way to handle this. Possibly with an unsafeToString and a safe toString with a wrap.
         try {
             for (int i = 1; i < this.length; i++) {
                 char next = edgeMapCopy.get(current).remove(0);
@@ -120,7 +118,7 @@ public class Traverse {
                 current = next;
             }
         } catch (IndexOutOfBoundsException e) {
-            return super.toString();
+            throw new IllegalStateException("Traverse is not fully connected and cannot be converted to a string.");
         }
 
         return result.toString();

--- a/src/test/java/org/pvv/shufflegene/DinculeotideTest.java
+++ b/src/test/java/org/pvv/shufflegene/DinculeotideTest.java
@@ -35,7 +35,7 @@ public class DinculeotideTest {
     }
 
     @Test
-    public void testShuffle() throws InvalidInputException {
+    public void testShuffle() throws InvalidInputException, IllegalStateException {
         String input = "ACAGGATTCAGATTAGCCCGGAAATTTAAC";
         for (int i = 0; i < 10; i++) {
             String output = DinucleotideShuffle.shuffleSequence(input);
@@ -48,7 +48,7 @@ public class DinculeotideTest {
     }
 
     @Test
-    public void shuffleShortSequence() throws InvalidInputException {
+    public void shuffleShortSequence() throws InvalidInputException, IllegalStateException {
         String input = "AC";
         String output = DinucleotideShuffle.shuffleSequence(input);
         //There's only one way to preserve the dinucleotide frequency, which is to return the same sequence.


### PR DESCRIPTION
- Handle attempts to remove an edge that does not exist in `Traverse`
- refactor `Traverse.toString()` to `Traverse.unsafeToString()` to highlight that this method only works when the traverse is in a good state.